### PR TITLE
Correctly tag releases with semvar version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,7 +42,7 @@ jobs:
           tags: |
             type=sha
             type=raw,value=branch-${{ env.REF_NAME }},enable=${{ env.REF_NAME != 'main' }}
-            type=raw,value=release-${{ env.MODIFIED_REF_NAME }},enable=${{ startsWith(env.REF_NAME, 'v') }}
+            type=raw,value=${{ env.MODIFIED_REF_NAME }},enable=${{ startsWith(env.REF_NAME, 'v') }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
There was a mistake in https://github.com/qpoint-io/kubernetes-qtap-init/pull/7. The `release-` prefix wasn't removed.